### PR TITLE
Show headers on subdirectory listings

### DIFF
--- a/lib/index
+++ b/lib/index
@@ -16,7 +16,7 @@ Dir-List-Template: dirlist.html
 Dir-List-Entry: <li class="Par{parity}"><a href="{dir|indexuri|url}">{dir|html|slashwbr}</a>
 Date-List-Template: datelist.html
 Date-List-Entry: <li class="Par{parity}"><span class="Date">[{datestr}]</span> <a href="{relroot}/{dir|url}/{name|url}">{dir|html|slashwbr}/<wbr>{name|html}</a>
-Subdir-List-Entry: <li class="Par{parity}"><a href="{relroot}/indexes/{dir|indexuri|url}">{dir|html|slashwbr}</a>
+Subdir-List-Entry: <li class="Par{parity}"><a href="{relroot}/indexes/{dir|indexuri|url}">{dir|html|slashwbr}</a>{?header}: <span class="DirectoryHeader">{header}</span>{/}
 Dir-Metadata: {?ifwiki}<p>{[ifwiki}{?ifwiki:first}IFWiki: {:}, {/}<a href="https://www.ifwiki.org/{ifwiki:value|wikipage|url}">{ifwiki:value|html}</a>{]}</p>{/}
 File-List-Entry: <dt class="Par{parity}"><a href={?linkdir}{relroot}/indexes/{linkdir|indexuri|url}{:}"{relroot}/{dir|url}/{name|url}"{/}>{name|html}</a>{?date} <span class="Date">[{datestr}]</span>{/}
     {_unboxlink}

--- a/testdata/indexes/if-archive.html
+++ b/testdata/indexes/if-archive.html
@@ -74,9 +74,10 @@ Or, go delving into the hierarchical tree shown here.
 
 <h3 class="ListHeader" id="subdirheader">4 Subdirectories</h3>
 <ul id="subdirlist">
-<li class="ParEven"><a href="../indexes/if-archiveXart.html">if-archive/<wbr>art</a>
+<li class="ParEven"><a href="../indexes/if-archiveXart.html">if-archive/<wbr>art</a>: <span class="DirectoryHeader"><p>Files from an art show:
+<a href="http://example.com/art/">http://example.com/art/</a></p></span>
 <li class="ParOdd"><a href="../indexes/if-archiveXcomp.html">if-archive/<wbr>comp</a>
-<li class="ParEven"><a href="../indexes/if-archiveXgames.html">if-archive/<wbr>games</a>
+<li class="ParEven"><a href="../indexes/if-archiveXgames.html">if-archive/<wbr>games</a>: <span class="DirectoryHeader"><p>Hey: these are some game files.</p></span>
 <li class="ParOdd"><a href="../indexes/if-archiveXspace%20dir.html">if-archive/<wbr>space dir</a>
 
 </ul>

--- a/testdata/indexes/if-archive/index.html
+++ b/testdata/indexes/if-archive/index.html
@@ -74,9 +74,10 @@ Or, go delving into the hierarchical tree shown here.
 
 <h3 class="ListHeader" id="subdirheader">4 Subdirectories</h3>
 <ul id="subdirlist">
-<li class="ParEven"><a href="../../indexes/if-archive/art/">if-archive/<wbr>art</a>
+<li class="ParEven"><a href="../../indexes/if-archive/art/">if-archive/<wbr>art</a>: <span class="DirectoryHeader"><p>Files from an art show:
+<a href="http://example.com/art/">http://example.com/art/</a></p></span>
 <li class="ParOdd"><a href="../../indexes/if-archive/comp/">if-archive/<wbr>comp</a>
-<li class="ParEven"><a href="../../indexes/if-archive/games/">if-archive/<wbr>games</a>
+<li class="ParEven"><a href="../../indexes/if-archive/games/">if-archive/<wbr>games</a>: <span class="DirectoryHeader"><p>Hey: these are some game files.</p></span>
 <li class="ParOdd"><a href="../../indexes/if-archive/space%20dir/">if-archive/<wbr>space dir</a>
 
 </ul>


### PR DESCRIPTION
@erkyrath

Today, when you navigate to https://ifarchive.org/indexes/if-archive/ you see a list of directories, with no description of what's _in_ those directories. Some of them are very mysteriously named, e.g. `info`, `collections`, etc. To learn what's inside, you have to click on each one, and read the metadata on the subsequent page.

In this PR, I'm adding descriptions to the bulleted list of subdirectory entries, so you can see what each directory contains before you click on it. (It's the directory "header," the first line of the `Index` file in that directory.)

This PR is stacked on top of PR https://github.com/iftechfoundation/ifarchive-ifmap-py/pull/15 (because the actual `Index` directory headers weren't in the test data prior to that; they were just hard-coded in `Master-Index`). If/when that PR merges, I'll update this PR to target the main branch of `ifarchive-ifmap-py`.

The PR generates the descriptions wrapped in `<p>` tags, so I've also wrapped them in a `<span class="DirectoryHeader">` tag.

As I'm imagining it, before merging this PR, we'd add a CSS rule to https://ifarchive.org/misc/ifarchive.css like this:

```css
.DirectoryHeader p {
    display: inline;
}
```

That way, the `<p>` tags would render inline without adding `<p>`'s vertical margin.

When I manually add that rule in Chrome DevTools, `testdata/indexes/if-archive.html` looks like this:

![Screenshot 2024-01-28 at 12 25 40 AM](https://github.com/dfabulich/ifarchive-ifmap-py/assets/96150/78db89d4-6357-4d09-b953-df34744a50a2)

